### PR TITLE
Add gen versions for selection of medical benchmarks

### DIFF
--- a/lm_eval/tasks/medmcqa_g2b/medmcqa_g2b_gen.yaml
+++ b/lm_eval/tasks/medmcqa_g2b/medmcqa_g2b_gen.yaml
@@ -1,0 +1,17 @@
+include: medmcqa_g2b.yaml
+task: medmcqa_g2b_gen
+output_type: generate_until
+description: "Answer the following question. Please keep your answers short and only return the letter corresponding to the right answer:\n\n"
+process_results: !function utils.process_results_gen
+repeats: 5
+filter_list:
+  - name: "sample_response"
+    filter:
+      - function: "regex"
+        regex_pattern: '(?=(A|B|C|D)(\s*|\W))'
+      - function: "majority_vote"
+      - function: "take_first"
+generation_kwargs:
+  do_sample: true
+  temperature: 0.2
+  max_gen_toks: 2

--- a/lm_eval/tasks/medmcqa_g2b/utils.py
+++ b/lm_eval/tasks/medmcqa_g2b/utils.py
@@ -1,0 +1,12 @@
+# original from https://github.com/oskarvanderwal/grounded-bias-eval/blob/main/bias_benchmarks/custom_tasks/shadr.py
+import ast
+import numpy as np
+
+def process_results_gen(doc, results):
+
+    if doc["cop"] == results[0]:
+        acc = 1
+    else:
+        acc = 0
+
+    return {"acc": acc}

--- a/lm_eval/tasks/medmcqa_orig_filtered/medmcqa_orig_filtered_gen.yaml
+++ b/lm_eval/tasks/medmcqa_orig_filtered/medmcqa_orig_filtered_gen.yaml
@@ -1,0 +1,17 @@
+include: medmcqa_orig_filtered.yaml
+task: medmcqa_orig_filtered_gen
+output_type: generate_until
+description: "Answer the following question. Please keep your answers short and only return the letter corresponding to the right answer:\n\n"
+process_results: !function utils.process_results_gen
+repeats: 5
+filter_list:
+  - name: "sample_response"
+    filter:
+      - function: "regex"
+        regex_pattern: '(?=(A|B|C|D)(\s*|\W))'
+      - function: "majority_vote"
+      - function: "take_first"
+generation_kwargs:
+  do_sample: true
+  temperature: 0.2
+  max_gen_toks: 2

--- a/lm_eval/tasks/medmcqa_orig_filtered/utils.py
+++ b/lm_eval/tasks/medmcqa_orig_filtered/utils.py
@@ -1,0 +1,12 @@
+# original from https://github.com/oskarvanderwal/grounded-bias-eval/blob/main/bias_benchmarks/custom_tasks/shadr.py
+import ast
+import numpy as np
+
+def process_results_gen(doc, results):
+
+    if doc["cop"] == results[0]:
+        acc = 1
+    else:
+        acc = 0
+
+    return {"acc": acc}

--- a/lm_eval/tasks/medqa/medqa_relabel_gen.yaml
+++ b/lm_eval/tasks/medqa/medqa_relabel_gen.yaml
@@ -1,0 +1,17 @@
+include: medqa_relabel.yaml
+task: medqa_relabel_gen
+output_type: generate_until
+description: "Answer the following question. Please keep your answers short and only return the letter corresponding to the right answer:\n\n"
+process_results: !function utils.process_results_gen
+repeats: 5
+filter_list:
+  - name: "sample_response"
+    filter:
+      - function: "regex"
+        regex_pattern: '(?=(A|B|C|D)(\s*|\W))'
+      - function: "majority_vote"
+      - function: "take_first"
+generation_kwargs:
+  do_sample: true
+  temperature: 0.2
+  max_gen_toks: 2

--- a/lm_eval/tasks/medqa/utils.py
+++ b/lm_eval/tasks/medqa/utils.py
@@ -1,0 +1,12 @@
+# original from https://github.com/oskarvanderwal/grounded-bias-eval/blob/main/bias_benchmarks/custom_tasks/shadr.py
+import ast
+import numpy as np
+
+def process_results_gen(doc, results):
+
+    if doc["label"] == results[0]:
+        acc = 1
+    else:
+        acc = 0
+
+    return {"acc": acc}

--- a/lm_eval/tasks/medqa_g2b/medqa_g2b_gen.yaml
+++ b/lm_eval/tasks/medqa_g2b/medqa_g2b_gen.yaml
@@ -1,0 +1,17 @@
+include: medqa_g2b.yaml
+task: medqa_4options_g2b_gen
+output_type: generate_until
+description: "Answer the following question. Please keep your answers short and only return the letter corresponding to the right answer:\n\n"
+process_results: !function utils.process_results_gen
+repeats: 5
+filter_list:
+  - name: "sample_response"
+    filter:
+      - function: "regex"
+        regex_pattern: '(?=(A|B|C|D)(\s*|\W))'
+      - function: "majority_vote"
+      - function: "take_first"
+generation_kwargs:
+  do_sample: true
+  temperature: 0.2
+  max_gen_toks: 2

--- a/lm_eval/tasks/medqa_g2b/utils.py
+++ b/lm_eval/tasks/medqa_g2b/utils.py
@@ -1,0 +1,12 @@
+# original from https://github.com/oskarvanderwal/grounded-bias-eval/blob/main/bias_benchmarks/custom_tasks/shadr.py
+import ast
+import numpy as np
+
+def process_results_gen(doc, results):
+
+    if doc["label"] == results[0]:
+        acc = 1
+    else:
+        acc = 0
+
+    return {"acc": acc}

--- a/lm_eval/tasks/medqa_orig_filtered/medqa_orig_filtered_gen.yaml
+++ b/lm_eval/tasks/medqa_orig_filtered/medqa_orig_filtered_gen.yaml
@@ -1,0 +1,17 @@
+include: medqa_orig_filtered.yaml
+task: medqa_4options_orig_filtered_gen
+output_type: generate_until
+description: "Answer the following question. Please keep your answers short and only return the letter corresponding to the right answer:\n\n"
+process_results: !function utils.process_results_gen
+repeats: 5
+filter_list:
+  - name: "sample_response"
+    filter:
+      - function: "regex"
+        regex_pattern: '(?=(A|B|C|D)(\s*|\W))'
+      - function: "majority_vote"
+      - function: "take_first"
+generation_kwargs:
+  do_sample: true
+  temperature: 0.2
+  max_gen_toks: 2

--- a/lm_eval/tasks/medqa_orig_filtered/utils.py
+++ b/lm_eval/tasks/medqa_orig_filtered/utils.py
@@ -1,0 +1,12 @@
+# original from https://github.com/oskarvanderwal/grounded-bias-eval/blob/main/bias_benchmarks/custom_tasks/shadr.py
+import ast
+import numpy as np
+
+def process_results_gen(doc, results):
+
+    if doc["label"] == results[0]:
+        acc = 1
+    else:
+        acc = 0
+
+    return {"acc": acc}

--- a/lm_eval/tasks/usmle_sa_step1/usmle_sa_step1_gen.yaml
+++ b/lm_eval/tasks/usmle_sa_step1/usmle_sa_step1_gen.yaml
@@ -1,0 +1,17 @@
+include: usmle_sa_step1.yaml
+task: usmle_sa_step1_gen
+output_type: generate_until
+description: "Answer the following question. Please keep your answers short and only return the letter corresponding to the right answer:\n\n"
+process_results: !function utils.process_results_gen
+repeats: 5
+filter_list:
+  - name: "sample_response"
+    filter:
+      - function: "regex"
+        regex_pattern: '(?=(A|B|C|D|E|F|G)(\s*|\W))'
+      - function: "majority_vote"
+      - function: "take_first"
+generation_kwargs:
+  do_sample: true
+  temperature: 0.2
+  max_gen_toks: 2

--- a/lm_eval/tasks/usmle_sa_step1/utils.py
+++ b/lm_eval/tasks/usmle_sa_step1/utils.py
@@ -1,0 +1,12 @@
+# original from https://github.com/oskarvanderwal/grounded-bias-eval/blob/main/bias_benchmarks/custom_tasks/shadr.py
+import ast
+import numpy as np
+
+def process_results_gen(doc, results):
+
+    if doc["answer_idx"] == results[0]:
+        acc = 1
+    else:
+        acc = 0
+
+    return {"acc": acc}

--- a/lm_eval/tasks/usmle_sa_step2/usmle_sa_step2_gen.yaml
+++ b/lm_eval/tasks/usmle_sa_step2/usmle_sa_step2_gen.yaml
@@ -1,0 +1,17 @@
+include: usmle_sa_step2.yaml
+task: usmle_sa_step2_gen
+output_type: generate_until
+description: "Answer the following question. Please keep your answers short and only return the letter corresponding to the right answer:\n\n"
+process_results: !function utils.process_results_gen
+repeats: 5
+filter_list:
+  - name: "sample_response"
+    filter:
+      - function: "regex"
+        regex_pattern: '(?=(A|B|C|D|E|F|G)(\s*|\W))'
+      - function: "majority_vote"
+      - function: "take_first"
+generation_kwargs:
+  do_sample: true
+  temperature: 0.2
+  max_gen_toks: 2

--- a/lm_eval/tasks/usmle_sa_step2/utils.py
+++ b/lm_eval/tasks/usmle_sa_step2/utils.py
@@ -1,0 +1,12 @@
+# original from https://github.com/oskarvanderwal/grounded-bias-eval/blob/main/bias_benchmarks/custom_tasks/shadr.py
+import ast
+import numpy as np
+
+def process_results_gen(doc, results):
+
+    if doc["answer_idx"] == results[0]:
+        acc = 1
+    else:
+        acc = 0
+
+    return {"acc": acc}

--- a/lm_eval/tasks/usmle_sa_step3/usmle_sa_step3_gen.yaml
+++ b/lm_eval/tasks/usmle_sa_step3/usmle_sa_step3_gen.yaml
@@ -1,0 +1,17 @@
+include: usmle_sa_step3.yaml
+task: usmle_sa_step3_gen
+output_type: generate_until
+description: "Answer the following question. Please keep your answers short and only return the letter corresponding to the right answer:\n\n"
+process_results: !function utils.process_results_gen
+repeats: 5
+filter_list:
+  - name: "sample_response"
+    filter:
+      - function: "regex"
+        regex_pattern: '(?=(A|B|C|D|E|F|G)(\s*|\W))'
+      - function: "majority_vote"
+      - function: "take_first"
+generation_kwargs:
+  do_sample: true
+  temperature: 0.2
+  max_gen_toks: 2

--- a/lm_eval/tasks/usmle_sa_step3/utils.py
+++ b/lm_eval/tasks/usmle_sa_step3/utils.py
@@ -1,0 +1,12 @@
+# original from https://github.com/oskarvanderwal/grounded-bias-eval/blob/main/bias_benchmarks/custom_tasks/shadr.py
+import ast
+import numpy as np
+
+def process_results_gen(doc, results):
+
+    if doc["answer_idx"] == results[0]:
+        acc = 1
+    else:
+        acc = 0
+
+    return {"acc": acc}


### PR DESCRIPTION
Most of the metrics rely on sentence probabilities (logits) to score the LM's performance. However, lm-eval does currently not work for OpenAI and Anthropic model APIs, as these do not expose the logits.. To work around this, I have created a `_gen` version for some of the benchmarks: by sampling a response `k` times, extracting the k answers using regex, and then sampling the response by majority vote.

(I have to admit that I am not familiar with all these different versions of the benchmarks!)

All of the following choices can probably be optimized. It would be good if another person could have a look at these as well:
- The choices for `k` and `temp` are arbitrary. I do this mainly because some LMs generate empty responses.
- The `description` (the prompt with instructions before showing the question) is chosen such that it forces the LMs to respond succinctly, but there are probably better ways to phrase it out there! (i.e., I didn't do any prompt engineering :) ). Also, I am not familiar with these benchmarks, so also let me know whether the question makes sense: `Answer the following question. Please keep your answers short and only return the letter corresponding to the right answer:`
- Few-shot evaluation can help to evaluate LMs that do not so well with zero-shot prompting.

@shan23chen selected the following medical benchmarks in `bias4o.yaml`.
- [X] shadr
- [X] usmle_sa_step1
- [X] usmle_sa_step2
- [X] usmle_sa_step3
- [X] medqa_relabel
- [X] medmcqa_orig_filtered
- [ ] medqa_4options_orig_filtered
- [X] medmcqa_g2b
- [X] medqa_4options_g2b